### PR TITLE
Update Team CI to test log in AKSUpstreamTests

### DIFF
--- a/config/staging/aksEngineK8s_Akstest_staging.json
+++ b/config/staging/aksEngineK8s_Akstest_staging.json
@@ -5,8 +5,8 @@
 		"folderPath": "AKSEngine-E2E/Template",
 		"dvmLogFilePath": "/var/log/azure/deploy-script-dvm.log",
 		"aksEngine": {
-			"githubRepo": "Azure/aks-engine",
-			"githubBranch": "patch-release-v0.46.1",
+			"githubRepo": "haofan-ms/aks-engine",
+			"githubBranch": "e2e-test-debug-log",
 			"apiModel": "https://raw.githubusercontent.com/msazurestackworkloads/azurestack-gallery/aks-e2e-release/AKSEngine-E2E/Template/azurestack_template.json",
 			"upgradeVersion": "1.16.1",
 			"nodeCount": 5,


### PR DESCRIPTION
Additional log in AKSUpstreamTests are in https://github.com/haofan-ms/aks-engine/commit/179e1bb102d1bef63e26f49c658b84dc0054d463.

This will help narrow down the port-forward error to a specific Kubernetes version.