### PR TITLE
Revert AKSe repo reference before test

### DIFF
--- a/config/staging/aksEngineK8s_Akstest_staging.json
+++ b/config/staging/aksEngineK8s_Akstest_staging.json
@@ -5,8 +5,8 @@
 		"folderPath": "AKSEngine-E2E/Template",
 		"dvmLogFilePath": "/var/log/azure/deploy-script-dvm.log",
 		"aksEngine": {
-			"githubRepo": "haofan-ms/aks-engine",
-			"githubBranch": "e2e-test-debug-log",
+			"githubRepo": "Azure/aks-engine",
+			"githubBranch": "patch-release-v0.46.1",
 			"apiModel": "https://raw.githubusercontent.com/msazurestackworkloads/azurestack-gallery/aks-e2e-release/AKSEngine-E2E/Template/azurestack_template.json",
 			"upgradeVersion": "1.16.1",
 			"nodeCount": 5,


### PR DESCRIPTION
The AKSe Upstream Tests issues are mostly resolved at this time, thus reverting back to the AKSe repo reference before test.

Reference commit: https://github.com/msazurestackworkloads/kubetools/commit/fd2d110d8d1206ffd04b94b36ec8b5a50c6e1bd6