### PR TITLE
Update output log for wordpress installation

### DIFF
--- a/applications/wordpress/install_wordpress_using_helm.sh
+++ b/applications/wordpress/install_wordpress_using_helm.sh
@@ -61,11 +61,11 @@ done
 # Test fail if the either pod is not running
 failedPods=""
 if [[ -z "$mariadbPodstatus" ]]; then
-    $failedPods="mariadb"
+    failedPods="mariadb"
 fi
 
 if [[ -z "$wdpressPodstatus" ]]; then
-    $failedPods="wordpress, "$failedPods
+    failedPods="wordpress, ${failedPods}"
 fi
 
 if [[ ! -z "$failedPods" ]]; then


### PR DESCRIPTION
When wordpress pods failed, error `./install_wordpress_using_helm.sh: line 68: =wordpress, : command not found` was hit when generating the output log. Update the script to resolve that.