### PR TITLE
Web-Ingress CI Update

### DIFF
--- a/applications/webapp_ingress/deploy.sh
+++ b/applications/webapp_ingress/deploy.sh
@@ -141,7 +141,7 @@ touch $LOG_FILENAME
         
         loop=0
         while [ $loop -lt 20 ]; do
-            IP_ADDRESS=$(ssh -i $IDENTITY_FILE $USER_NAME@$MASTER_IP "kubectl get services -n $NAMESPACE_NAME -o json | jq --arg release $ingressName --arg component 'controller' '.items[] | select(.spec.selector.component == \$component) | select(.metadata.labels.release == \$release) | .status.loadBalancer.ingress[0].ip' | grep -oP '(\d{1,3}\.){1,3}\d{1,3}' || true")
+            IP_ADDRESS=$(ssh -i $IDENTITY_FILE $USER_NAME@$MASTER_IP "kubectl get services -n $NAMESPACE_NAME -o json | jq --arg release $ingressName --arg component 'controller' '.items[] | select(.metadata.labels.component == \$component) | select(.metadata.labels.release == \$release) | .status.loadBalancer.ingress[0].ip' | grep -oP '(\d{1,3}\.){1,3}\d{1,3}' || true")
             if [ -z "$IP_ADDRESS" ]; then
                 log_level -i "External IP is not assigned. We we will retry after some time."
                 sleep 30s

--- a/applications/webapp_ingress/deploy.sh
+++ b/applications/webapp_ingress/deploy.sh
@@ -210,7 +210,7 @@ touch $LOG_FILENAME
         let i=i+1
     done
     
-    deploymentNames=($(ssh -i $IDENTITY_FILE $USER_NAME@$MASTER_IP "kubectl get services -n $NAMESPACE_NAME -o json | jq --arg type 'ClusterIP' '.items[] | select(.spec.type == \$type) | select(.spec.selector.component == null) | .metadata.name'"))
+    deploymentNames=($(ssh -i $IDENTITY_FILE $USER_NAME@$MASTER_IP "kubectl get services -n $NAMESPACE_NAME -o json | jq --arg type 'ClusterIP' '.items[] | select(.spec.type == \$type) | select(.metadata.labels.component == null) | .metadata.name'"))
     deploymentCount="${#deploymentNames[@]}"
     log_level -i "App Deployment count is $deploymentCount"
     if [ $deploymentCount -eq $MAX_INGRESS_SERVICE_COUNT ]; then

--- a/applications/webapp_ingress/validate.sh
+++ b/applications/webapp_ingress/validate.sh
@@ -72,7 +72,7 @@ touch $LOG_FILENAME
 
         certificateFileName=$OUTPUT_FOLDER/$ingressName-$CERT_FILENAME
         secretkeyFileName=$OUTPUT_FOLDER/$ingressName-$SECRETKEY_FILEANME
-        ipAddress=$(ssh -i $IDENTITY_FILE $USER_NAME@$MASTER_IP "kubectl get services -n $NAMESPACE_NAME -o json | jq --arg release $ingressName --arg component 'controller' '.items[] | select(.spec.selector.component == \$component) | select(.metadata.labels.release == \$release) | .status.loadBalancer.ingress[0].ip' | grep -oP '(\d{1,3}\.){1,3}\d{1,3}' || true")
+        ipAddress=$(ssh -i $IDENTITY_FILE $USER_NAME@$MASTER_IP "kubectl get services -n $NAMESPACE_NAME -o json | jq --arg release $ingressName --arg component 'controller' '.items[] | select(.metadata.labels.component == \$component) | select(.metadata.labels.release == \$release) | .status.loadBalancer.ingress[0].ip' | grep -oP '(\d{1,3}\.){1,3}\d{1,3}' || true")
         if [ -z "$ipAddress" ]; then
             log_level -e "External IP not found for ingress $ingressName."
             FAILED_INGRESS_SERVERS="$FAILED_INGRESS_SERVERS$ingressName,"


### PR DESCRIPTION
The nginx-ingress from helm chart (`helm install stable/nginx-ingress`) no longer have the `.spec.selector.component` of "controller", instead it's in `.metadata.labels.component`. That is causing problem with the Web-Ingress CI test. Details as below:
```
$ kubectl get svc -n ingress-basic -o json | jq '.items[] | select(.metadata.labels.release == "ingress-1")'

{
  "apiVersion": "v1",
  "kind": "Service",
  "metadata": {
    "creationTimestamp": "2020-03-24T18:49:30Z",
    "labels": {
      "app": "nginx-ingress",
      "chart": "nginx-ingress-1.34.2",
      "component": "controller",
      "heritage": "Tiller",
      "release": "ingress-1"
    },
    "name": "ingress-1-nginx-ingress-controller",
    "namespace": "ingress-basic",
    "resourceVersion": "2495",
    "selfLink": "/api/v1/namespaces/ingress-basic/services/ingress-1-nginx-ingress-controller",
    "uid": "10f2e25d-c9b5-47c0-b981-360af976dac3"
  },
  "spec": {
    "clusterIP": "10.0.48.122",
    "externalTrafficPolicy": "Cluster",
    "ports": [
      {
        "name": "http",
        "nodePort": 30041,
        "port": 80,
        "protocol": "TCP",
        "targetPort": "http"
      },
      {
        "name": "https",
        "nodePort": 31672,
        "port": 443,
        "protocol": "TCP",
        "targetPort": "https"
      }
    ],
    "selector": {
      "app": "nginx-ingress",
      "app.kubernetes.io/component": "controller",
      "release": "ingress-1"
    },
    "sessionAffinity": "None",
    "type": "LoadBalancer"
  },
  "status": {
    "loadBalancer": {
      "ingress": [
        {
          "ip": "100.83.26.195"
        }
      ]
    }
  }
}
{
  "apiVersion": "v1",
  "kind": "Service",
  "metadata": {
    "creationTimestamp": "2020-03-24T18:49:30Z",
    "labels": {
      "app": "nginx-ingress",
      "chart": "nginx-ingress-1.34.2",
      "component": "default-backend",
      "heritage": "Tiller",
      "release": "ingress-1"
    },
    "name": "ingress-1-nginx-ingress-default-backend",
    "namespace": "ingress-basic",
    "resourceVersion": "2386",
    "selfLink": "/api/v1/namespaces/ingress-basic/services/ingress-1-nginx-ingress-default-backend",
    "uid": "58d7a66f-22da-4eb8-960f-7e2896483be7"
  },
  "spec": {
    "clusterIP": "10.0.63.229",
    "ports": [
      {
        "name": "http",
        "port": 80,
        "protocol": "TCP",
        "targetPort": "http"
      }
    ],
    "selector": {
      "app": "nginx-ingress",
      "app.kubernetes.io/component": "default-backend",
      "release": "ingress-1"
    },
    "sessionAffinity": "None",
    "type": "ClusterIP"
  },
  "status": {
    "loadBalancer": {}
  }
}